### PR TITLE
Feature/add resource pojos

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic",
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- Lombok Dependancy-->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.38</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -62,6 +69,20 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<!-- Lombok Plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.38</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAbstract.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAbstract.java
@@ -31,4 +31,94 @@ public abstract class ResourceAbstract {
     @Setter
     protected double price;
 
+    /**
+     * Checks if the resource is available.
+     * 
+     * @return true if the resource is available (i.e., the quantity is greater than zero), false otherwise.
+     */
+    public boolean isAvailable() {
+        return available > 0;
+    }
+
+    /**
+     * Returns a summary of the resource, useful for logging or displaying information.
+     * <p>
+     * The summary will be in the format of a JSON object, with the following fields:
+     * <ul>
+     *     <li>id: the unique identifier of the resource</li>
+     *     <li>TYPE: the type of the resource, e.g. "Display", "Audio", etc.</li>
+     *     <li>name: the name of the resource</li>
+     *     <li>description: a brief description of the resource</li>
+     *     <li>available: the number of resources available</li>
+     *     <li>price: the price of the resource in dollars</li>
+     * </ul>
+     * </p>
+     */
+    public String getSummary() {
+        return "Resource{\n" +
+                "id = " + id +
+                ", TYPE = '" + TYPE + '\'' +
+                ", name = '" + name + '\'' +
+                ", description = '" + description + '\'' +
+                ", available = " + available +
+                ", price = $" + price +
+                "\n}";
+    }
+
+    /**
+     * Compares this resource with another resource to determine equality.
+     *
+     * @param resource the resource to compare with this resource
+     * @return true if the IDs of both resources are equal, false otherwise
+     */
+    public boolean equals(ResourceAbstract resource) {
+        return this.id == resource.getId();
+    }
+
+    /**
+     * Attempts to reserve one resource, if available.
+     * <p>
+     * If there is at least one resource available, this method will decrement the available count by one and return true.
+     * Otherwise, it will return false.
+     * </p>
+     * @return true if the resource was reserved, false if not
+     */
+    public boolean reserveOne() {
+        if (available > 0) {
+            available--;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Attempts to reserve multiple resources, if available.
+     * <p>
+     * If there are at least <code>quantity</code> resources available, this method will decrement the available count by <code>quantity</code> and return true.
+     * Otherwise, it will return false.
+     * </p>
+     * @param quantity the number of resources to reserve
+     * @return true if the resources were reserved, false if not
+     */
+    public boolean reserve(int quantity) {
+        if (available >= quantity) {
+            available -= quantity;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Attempts to return one resource, if not already fully reserved.
+     * <p>
+     * If there are available resources, this method will increment the available count by one and return true.
+     * Otherwise, it will return false.
+     * </p>
+     * @return true if the resource was returned, false if not
+     */
+    public boolean returnOne() {
+        available++;
+        return true;
+    }
+
 }

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAbstract.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAbstract.java
@@ -1,0 +1,21 @@
+package com.teamsamuelsagar.coworkingspace.pojos;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public abstract class ResourceAbstract {
+
+    @Getter
+    @Setter
+    Protected long id;
+    @Getter
+    @Setter
+    Protected String TYPE; // Should this be an enum? I'll set up the enum class to be implemented later if we want
+    @Getter
+    @Setter
+    Protected int available;
+    @Getter
+    @Setter
+    Protected double price;
+
+}

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAbstract.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAbstract.java
@@ -1,5 +1,7 @@
 package com.teamsamuelsagar.coworkingspace.pojos;
 
+//import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,15 +9,18 @@ public abstract class ResourceAbstract {
 
     @Getter
     @Setter
-    Protected long id;
+    protected long id;
+
     @Getter
     @Setter
-    Protected String TYPE; // Should this be an enum? I'll set up the enum class to be implemented later if we want
+    protected String TYPE; // ResourceType TYPE; --- Should this be an enum, ResourceType?
+
     @Getter
     @Setter
-    Protected int available;
+    protected int available;
+    
     @Getter
     @Setter
-    Protected double price;
+    protected double price;
 
 }

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAbstract.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAbstract.java
@@ -17,8 +17,16 @@ public abstract class ResourceAbstract {
 
     @Getter
     @Setter
+    protected String name;
+
+    @Getter
+    @Setter
+    protected String description;
+
+    @Getter
+    @Setter
     protected int available;
-    
+
     @Getter
     @Setter
     protected double price;

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAudio.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAudio.java
@@ -1,0 +1,31 @@
+package com.teamsamuelsagar.coworkingspace.pojos;
+
+//import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class ResourceAudio extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private String name;
+
+    @Getter
+    @Setter
+    private String description;
+
+    public ResourceAudio() {
+        this.TYPE = "Audio"; // ResourceType.Audio;
+    }
+
+    public ResourceAudio(long id, int available, double price, String name, String description) {
+        this.TYPE = "Audio"; // ResourceType.Audio;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAudio.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAudio.java
@@ -1,8 +1,15 @@
 package com.teamsamuelsagar.coworkingspace.pojos;
 
+import lombok.Getter;
+import lombok.Setter;
+
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
 public class ResourceAudio extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private boolean isWireless;
 
     public ResourceAudio() {
         this.TYPE = "Audio"; // ResourceType.Audio;
@@ -15,6 +22,44 @@ public class ResourceAudio extends ResourceAbstract {
         this.price = price;
         this.name = name;
         this.description = description;
+    }
+
+    public ResourceAudio(long id, int available, double price, String name, String description, boolean wireless) {
+        this.TYPE = "Audio"; // ResourceType.Audio;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+        this.isWireless = wireless;
+    }
+
+    /**
+     * Returns a summary of the resource, including audio-specific attributes.
+     * <p>
+     * The summary will be in the format of a JSON object, with the following fields:
+     * <ul>
+     *     <li>id: the unique identifier of the resource</li>
+     *     <li>TYPE: the type of the resource, e.g. "Audio"</li>
+     *     <li>name: the name of the resource</li>
+     *     <li>description: a brief description of the resource</li>
+     *     <li>available: the number of resources available</li>
+     *     <li>price: the price of the resource in dollars</li>
+     *     <li>wireless: whether the resource is wireless</li>
+     * </ul>
+     * </p>
+     */
+    @Override
+    public String getSummary() {
+        return "Resource{\n" +
+                "id = " + id +
+                ", TYPE = '" + TYPE + '\'' +
+                ", name = '" + name + '\'' +
+                ", description = '" + description + '\'' +
+                ", available = " + available +
+                ", price = $" + price +
+                ", wireless = " + isWireless +
+                "\n}";
     }
 
 }

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAudio.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceAudio.java
@@ -2,18 +2,7 @@ package com.teamsamuelsagar.coworkingspace.pojos;
 
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
-import lombok.Getter;
-import lombok.Setter;
-
 public class ResourceAudio extends ResourceAbstract {
-
-    @Getter
-    @Setter
-    private String name;
-
-    @Getter
-    @Setter
-    private String description;
 
     public ResourceAudio() {
         this.TYPE = "Audio"; // ResourceType.Audio;

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceDisplay.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceDisplay.java
@@ -1,0 +1,31 @@
+package com.teamsamuelsagar.coworkingspace.pojos;
+
+//import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class ResourceDisplay extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private String name;
+
+    @Getter
+    @Setter
+    private String description;
+
+    public ResourceDisplay() {
+        this.TYPE = "Display"; // ResourceType.Display;
+    }
+
+    public ResourceDisplay(long id, int available, double price, String name, String description) {
+        this.TYPE = "Display"; // ResourceType.Display;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceDisplay.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceDisplay.java
@@ -2,18 +2,7 @@ package com.teamsamuelsagar.coworkingspace.pojos;
 
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
-import lombok.Getter;
-import lombok.Setter;
-
 public class ResourceDisplay extends ResourceAbstract {
-
-    @Getter
-    @Setter
-    private String name;
-
-    @Getter
-    @Setter
-    private String description;
 
     public ResourceDisplay() {
         this.TYPE = "Display"; // ResourceType.Display;

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceDisplay.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceDisplay.java
@@ -1,8 +1,23 @@
 package com.teamsamuelsagar.coworkingspace.pojos;
 
+import lombok.Getter;
+import lombok.Setter;
+
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
 public class ResourceDisplay extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private String screenSize;
+
+    @Getter
+    @Setter
+    private String resolution;
+
+    @Getter
+    @Setter
+    private boolean isPortable;
 
     public ResourceDisplay() {
         this.TYPE = "Display"; // ResourceType.Display;
@@ -15,6 +30,50 @@ public class ResourceDisplay extends ResourceAbstract {
         this.price = price;
         this.name = name;
         this.description = description;
+    }
+
+    public ResourceDisplay(long id, int available, double price, String name, String description, String screenSize, String resolution, boolean portable) {
+        this.TYPE = "Display"; // ResourceType.Display;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+        this.screenSize = screenSize;
+        this.resolution = resolution;
+        this.isPortable = portable;
+    }
+
+    /**
+     * Returns a summary of the display resource, including display-specific attributes.
+     * <p>
+     * The summary will be in the format of a JSON object, with the following fields:
+     * <ul>
+     *     <li>id: the unique identifier of the resource</li>
+     *     <li>TYPE: the type of the resource, e.g. "Display"</li>
+     *     <li>name: the name of the resource</li>
+     *     <li>description: a brief description of the resource</li>
+     *     <li>available: the number of resources available</li>
+     *     <li>price: the price of the resource in dollars</li>
+     *     <li>screenSize: the size of the display screen</li>
+     *     <li>resolution: the resolution of the display</li>
+     *     <li>portable: indicates whether the display is portable</li>
+     * </ul>
+     * </p>
+     */
+    @Override
+    public String getSummary() {
+        return "Resource{\n" +
+                "id = " + id +
+                ", TYPE = '" + TYPE + '\'' +
+                ", name = '" + name + '\'' +
+                ", description = '" + description + '\'' +
+                ", available = " + available +
+                ", price = $" + price +
+                ", screenSize = '" + screenSize + '\'' +
+                ", resolution = '" + resolution + '\'' +
+                ", portable = " + isPortable +
+                "\n}";
     }
 
 }

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceInteractiveDevice.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceInteractiveDevice.java
@@ -1,0 +1,31 @@
+package com.teamsamuelsagar.coworkingspace.pojos;
+
+//import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class ResourceInteractiveDevice extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private String name;
+
+    @Getter
+    @Setter
+    private String description;
+
+    public ResourceInteractiveDevice() {
+        this.TYPE = "InteractiveDevice"; // ResourceType.InteractiveDevice;
+    }
+
+    public ResourceInteractiveDevice(long id, int available, double price, String name, String description) {
+        this.TYPE = "InteractiveDevice"; // ResourceType.InteractiveDevice;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceInteractiveDevice.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceInteractiveDevice.java
@@ -2,18 +2,7 @@ package com.teamsamuelsagar.coworkingspace.pojos;
 
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
-import lombok.Getter;
-import lombok.Setter;
-
 public class ResourceInteractiveDevice extends ResourceAbstract {
-
-    @Getter
-    @Setter
-    private String name;
-
-    @Getter
-    @Setter
-    private String description;
 
     public ResourceInteractiveDevice() {
         this.TYPE = "InteractiveDevice"; // ResourceType.InteractiveDevice;

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceInteractiveDevice.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceInteractiveDevice.java
@@ -1,8 +1,23 @@
 package com.teamsamuelsagar.coworkingspace.pojos;
 
+import lombok.Getter;
+import lombok.Setter;
+
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
 public class ResourceInteractiveDevice extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private String screenSize;
+
+    @Getter
+    @Setter
+    private boolean isPortable;
+
+    @Getter
+    @Setter
+    private String platform; // e.g., "Windows", "Android", "Oculus"
 
     public ResourceInteractiveDevice() {
         this.TYPE = "InteractiveDevice"; // ResourceType.InteractiveDevice;
@@ -15,6 +30,50 @@ public class ResourceInteractiveDevice extends ResourceAbstract {
         this.price = price;
         this.name = name;
         this.description = description;
+    }
+
+    public ResourceInteractiveDevice(long id, int available, double price, String name, String description, String screenSize, boolean portable, String platform) {
+        this.TYPE = "InteractiveDevice"; // ResourceType.InteractiveDevice;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+        this.screenSize = screenSize;
+        this.isPortable = portable;
+        this.platform = platform;
+    }
+
+    /**
+     * Returns a summary of the interactive device resource, including interactive device-specific attributes.
+     * <p>
+     * The summary will be in the format of a JSON object, with the following fields:
+     * <ul>
+     *     <li>id: the unique identifier of the resource</li>
+     *     <li>TYPE: the type of the resource, e.g. "InteractiveDevice"</li>
+     *     <li>name: the name of the resource</li>
+     *     <li>description: a brief description of the resource</li>
+     *     <li>available: the number of resources available</li>
+     *     <li>price: the price of the resource in dollars</li>
+     *     <li>screenSize: the size of the device screen</li>
+     *     <li>isPortable: indicates whether the device is portable</li>
+     *     <li>platform: the platform of the device, e.g. "Windows", "Android", "Oculus"</li>
+     * </ul>
+     * </p>
+     */
+    @Override
+    public String getSummary() {
+        return "Resource{\n" +
+                "id = " + id +
+                ", TYPE = '" + TYPE + '\'' +
+                ", name = '" + name + '\'' +
+                ", description = '" + description + '\'' +
+                ", available = " + available +
+                ", price = $" + price +
+                ", screenSize = '" + screenSize + '\'' +
+                ", isPortable = " + isPortable +
+                ", platform = '" + platform + '\'' +
+                "\n}";
     }
 
 }

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceOther.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceOther.java
@@ -2,18 +2,7 @@ package com.teamsamuelsagar.coworkingspace.pojos;
 
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
-import lombok.Getter;
-import lombok.Setter;
-
 public class ResourceOther extends ResourceAbstract {
-
-    @Getter
-    @Setter
-    private String name;
-
-    @Getter
-    @Setter
-    private String description;
 
     public ResourceOther() {
         this.TYPE = "Other"; // ResourceType.Other;

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceOther.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceOther.java
@@ -1,0 +1,31 @@
+package com.teamsamuelsagar.coworkingspace.pojos;
+
+//import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class ResourceOther extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private String name;
+
+    @Getter
+    @Setter
+    private String description;
+
+    public ResourceOther() {
+        this.TYPE = "Other"; // ResourceType.Other;
+    }
+
+    public ResourceOther(long id, int available, double price, String name, String description) {
+        this.TYPE = "Other"; // ResourceType.Other;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceOther.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceOther.java
@@ -1,8 +1,35 @@
 package com.teamsamuelsagar.coworkingspace.pojos;
 
+import lombok.Getter;
+import lombok.Setter;
+
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
 public class ResourceOther extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private String length;
+
+    @Getter
+    @Setter
+    private String connectorType;
+
+    @Getter
+    @Setter
+    private boolean surgeProtected;
+
+    @Getter
+    @Setter
+    private String osType;
+
+    @Getter
+    @Setter
+    private String printType;
+
+    @Getter
+    @Setter
+    private boolean printColor;
 
     public ResourceOther() {
         this.TYPE = "Other"; // ResourceType.Other;
@@ -15,6 +42,59 @@ public class ResourceOther extends ResourceAbstract {
         this.price = price;
         this.name = name;
         this.description = description;
+    }
+
+    public ResourceOther(long id, int available, double price, String name, String description, String length, String connectorType, boolean surgeProtected, String osType, String printType, boolean printColor) {
+        this.TYPE = "Other"; // ResourceType.Other;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+        this.length = length;
+        this.connectorType = connectorType;
+        this.surgeProtected = surgeProtected;
+        this.osType = osType;
+        this.printType = printType;
+        this.printColor = printColor;
+    }
+
+    /**
+     * Returns a summary of the resource, including Other-specific attributes.
+     * <p>
+     * The summary will be in the format of a JSON object, with the following fields:
+     * <ul>
+     *     <li>id: the unique identifier of the resource</li>
+     *     <li>TYPE: the type of the resource, e.g. "Other"</li>
+     *     <li>name: the name of the resource</li>
+     *     <li>description: a brief description of the resource</li>
+     *     <li>available: the number of resources available</li>
+     *     <li>price: the price of the resource in dollars</li>
+     *     <li>length: the length of the cable</li>
+     *     <li>connectorType: the type of connector, e.g. HDMI, USB, etc.</li>
+     *     <li>surgeProtected: whether the resource has surge protection</li>
+     *     <li>osType: the type of operating system the resource is compatible with</li>
+     *     <li>printType: the type of printing the resource supports</li>
+     *     <li>printColor: whether the resource supports color printing</li>
+     * </ul>
+     * </p>
+     */
+    @Override
+    public String getSummary() {
+        return "Resource{\n" +
+                "id = " + id +
+                ", TYPE = '" + TYPE + '\'' +
+                ", name = '" + name + '\'' +
+                ", description = '" + description + '\'' +
+                ", available = " + available +
+                ", price = $" + price +
+                ", length = '" + length + '\'' +
+                ", connectorType = '" + connectorType + '\'' +
+                ", surgeProtected = " + surgeProtected +
+                ", osType = '" + osType + '\'' +
+                ", printType = '" + printType + '\'' +
+                ", printColor = " + printColor +
+                "\n}";
     }
 
 }

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceType.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceType.java
@@ -1,0 +1,11 @@
+package com.teamsamuelsagar.coworkingspace.pojos;
+
+public enum ResourceType {
+
+    Display, 
+    Audio, 
+    Video, 
+    InteractiveDevice,
+    Other
+
+}

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceVideo.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceVideo.java
@@ -1,0 +1,31 @@
+package com.teamsamuelsagar.coworkingspace.pojos;
+
+//import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class ResourceVideo extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private String name;
+
+    @Getter
+    @Setter
+    private String description;
+
+    public ResourceVideo() {
+        this.TYPE = "Video"; // ResourceType.Video;
+    }
+
+    public ResourceVideo(long id, int available, double price, String name, String description) {
+        this.TYPE = "Video"; // ResourceType.Video;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceVideo.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceVideo.java
@@ -1,8 +1,23 @@
 package com.teamsamuelsagar.coworkingspace.pojos;
 
+import lombok.Getter;
+import lombok.Setter;
+
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
 public class ResourceVideo extends ResourceAbstract {
+
+    @Getter
+    @Setter
+    private String fieldOfView;
+
+    @Getter
+    @Setter
+    private boolean isPortable;
+
+    @Getter
+    @Setter
+    private boolean hasMicrophone;
 
     public ResourceVideo() {
         this.TYPE = "Video"; // ResourceType.Video;
@@ -15,6 +30,33 @@ public class ResourceVideo extends ResourceAbstract {
         this.price = price;
         this.name = name;
         this.description = description;
+    }
+
+    public ResourceVideo(long id, int available, double price, String name, String description, String fov, boolean portable, boolean hasMicrophone) {
+        this.TYPE = "Video"; // ResourceType.Video;
+        this.id = id;
+        this.available = available;
+        this.price = price;
+        this.name = name;
+        this.description = description;
+        this.fieldOfView = fov;
+        this.isPortable = portable;
+        this.hasMicrophone = hasMicrophone;
+    }
+
+    @Override
+    public String getSummary() {
+        return "Resource{\n" +
+                "id = " + id +
+                ", TYPE = '" + TYPE + '\'' +
+                ", name = '" + name + '\'' +
+                ", description = '" + description + '\'' +
+                ", available = " + available +
+                ", price = $" + price +
+                ", fieldOfView = '" + fieldOfView + '\'' +
+                ", isPortable = " + isPortable +
+                ", hasMicrophone = " + hasMicrophone +
+                "\n}";
     }
 
 }

--- a/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceVideo.java
+++ b/src/main/java/com/teamsamuelsagar/coworkingspace/pojos/ResourceVideo.java
@@ -2,18 +2,7 @@ package com.teamsamuelsagar.coworkingspace.pojos;
 
 //import com.teamsamuelsagar.coworkingspace.pojos.ResourceType;
 
-import lombok.Getter;
-import lombok.Setter;
-
 public class ResourceVideo extends ResourceAbstract {
-
-    @Getter
-    @Setter
-    private String name;
-
-    @Getter
-    @Setter
-    private String description;
 
     public ResourceVideo() {
         this.TYPE = "Video"; // ResourceType.Video;


### PR DESCRIPTION
## Summary

Adds POJOs for the resources in our application. I created an abstract class as well as five implemented classes for each category of resource. Each class contains constructors and specific fields that relate only to their resource type. There is also a ResourceType enum class, if we want to implement that instead of using Strings. All new files are in the pojo/ directory.

## Details

- Introduced new class(es): `ResourceAbstract`, `ResourceAudio`, `ResourceDisplay`, `ResourceInteractiveDevice`, `ResourceOther`, `ResourceVideo`
- Updated `pom.xml` logic to include Lombok Annotations
- Created enum: `ResourceType`

## Scope of Changes

- [x] Backend logic
- [x] Entity or model classes (POJOs)
- [x] Enums/constants
- [ ] DTOs
- [ ] Controller/API
- [ ] Validation rules
- [ ] Frontend logic (if applicable)
- [ ] Tests

## Notes for Reviewers

- Please verify field names on `Resource` subclasses
- Let me know if the `ResourceType` enum structure makes sense or if we need to add more things to it
- Look through `ResourceOther` class and see if it makes more sense to split it into other resource classes (cord, laptops, printers, etc.)
